### PR TITLE
Assigning value to a constant declaration throws an error

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -72,7 +72,7 @@ UserSchema.methods.comparePassword = function(candidatePassword, cb) {
 
 // Send a verification token to this user
 UserSchema.methods.sendAuthyToken = function(cb) {
-    const self = this;
+    var self = this;
 
     if (!self.authyId) {
         // Register this user if it's a new user


### PR DESCRIPTION
The const declaration self has its value being reassigned in the scope and therefore throws an error. Changing its declaration to var solved the issue.